### PR TITLE
Add support for t_quartz_line.tbl

### DIFF
--- a/ed9_Daybreak1/ElementSlotRate.json
+++ b/ed9_Daybreak1/ElementSlotRate.json
@@ -1,0 +1,6 @@
+{
+    "version": 1,
+    "schema": {
+        "float": "f32"
+    }
+}

--- a/ed9_Daybreak1/QuartzLineParam.json
+++ b/ed9_Daybreak1/QuartzLineParam.json
@@ -1,0 +1,19 @@
+{
+    "version": 1,
+    "schema": {
+        "character_id": "u32",
+        "quartz_line": "u32",
+        "unknown_u32": "u32",
+        "unknown_u16": "u16",
+        "orbment_slots": {
+            "repeat": 3,
+            "type": {
+                "element": "u16",
+                "empty": "u16",
+                "open_cost": "u16",
+                "ep_boost": "u16"
+                 }
+             },
+        "total_line_slots": "u16"
+    }
+}

--- a/ed9_Daybreak2/ElementSlotRate.json
+++ b/ed9_Daybreak2/ElementSlotRate.json
@@ -1,0 +1,6 @@
+{
+    "version": 1,
+    "schema": {
+        "float": "f32"
+    }
+}

--- a/ed9_Daybreak2/QuartzLineParam.json
+++ b/ed9_Daybreak2/QuartzLineParam.json
@@ -1,0 +1,19 @@
+{
+    "version": 1,
+    "schema": {
+        "character_id": "u32",
+        "quartz_line": "u32",
+        "unknown_u32": "u32",
+        "unknown_u16": "u16",
+        "orbment_slots": {
+            "repeat": 3,
+            "type": {
+                "element": "u16",
+                "empty": "u16",
+                "open_cost": "u16",
+                "ep_boost": "u16"
+                 }
+             },
+        "total_line_slots": "u16"
+    }
+}


### PR DESCRIPTION
This table remains the same layout across all three games (Trails through Daybreak 1, 2 and Horizon) but as Horizon is not out yet as of this moment, and not being supported yet, I've only included it for Daybreak 1 and 2. Roundtrip has been fully tested and this isn't a file touched by any currently opened pull requests.